### PR TITLE
Fix PyPi install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# make github and sdist happy
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup
+from os.path import abspath, dirname, join
+
+readme_fn = join(abspath(dirname(__file__)), 'README.rst')
 
 setup(name='LogPy',
     version = '1.0',
     description = 'Unorthodox logging for python',
-    long_description = open('README.rst').read(),
+    long_description = open(readme_fn).read(),
     author = 'Michal Hordecki',
     author_email = 'mhordecki@gmail.com',
     url = 'http://github.com/MHordecki/LogPy',


### PR DESCRIPTION
Installing with `pip-python3 install --user LogPy` raises the following exception:

``` python
Traceback (most recent call last):
    File "<string>", line 14, in <module>
    File ".../LogPy/setup.py", line 6, in <module>
    long_description = open('README.rst').read(),
IOError: [Errno 2] No such file or directory: 'README.rst'
```

Fix included. Kudos for the neat module!
